### PR TITLE
Show BTC average hashrate

### DIFF
--- a/src/config/entities.js
+++ b/src/config/entities.js
@@ -113,6 +113,12 @@ export default {
     filters: { name: 'Hs', args: [2] },
     threshold: 'hashes'
   },
+  btcAvgHashrate: {
+    title: 'btc avg hash rate',
+    icon: 'zap',
+    filters: { name: 'Hs', args: [3] },
+    threshold: 'hashes'
+  },
   hashrateComparedToBtcNetwork: {
     title: 'btc hash rate mining rsk',
     icon: 'rocket',

--- a/src/config/entityValues.js
+++ b/src/config/entityValues.js
@@ -34,6 +34,7 @@ export const TOTAL = (totals, date) => {
     avgBlockTime: totals.avgBlockTime,
     lastDifficulty: totals.lastDifficulty,
     avgHashrate: totals.avgHashrate,
+    btcAvgHashrate: totals.btcAvgHashrate,
     hashrateComparedToBtcNetwork: totals.hashrateComparedToBtcNetwork,
     uncles: totals.bestStats.block.uncles.length + '/' + totals.uncleCount,
     gasPrice: totals.bestStats.gasPrice,

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -28,6 +28,10 @@ export default function (types) {
           show: true,
           minimized: false
         },
+        btcAvgHashrate: {
+          show: false,
+          minimized: false
+        },
         hashrateComparedToBtcNetwork: {
           show: true,
           minimized: false

--- a/src/store/modules/backend/actions.js
+++ b/src/store/modules/backend/actions.js
@@ -41,6 +41,7 @@ export const socket_charts = ({ state, dispatch, commit }, data) => {
   commit('SET_TOTALS', { avgBlockTime: data.avgBlocktime })
 
   commit('SET_TOTALS', { avgHashrate: data.avgHashrate })
+  commit('SET_TOTALS', { btcAvgHashrate: data.btcAvgHashrate })
 
   commit('SET_TOTALS', { hashrateComparedToBtcNetwork: data.hashrateComparedToBtcNetwork })
 

--- a/src/store/modules/backend/state.js
+++ b/src/store/modules/backend/state.js
@@ -23,6 +23,7 @@ export default function () {
       avgBlockTime: 0,
       blockPropagationAvg: 0,
       avgHashrate: 0,
+      btcAvgHashrate: 0,
       hashrateComparedToBtcNetwork: 0,
       uncleCount: [],
       upTimeTotal: 0 // <---


### PR DESCRIPTION
Add a hidden component showing the BTC network hashrate along the already existing RSK hashrate and RSK/BTC ratio indicators